### PR TITLE
feat: 딴짓 기록 등록 기능 구현 (#5)

### DIFF
--- a/src/main/java/com/ddantime/ddantime/common/exception/ErrorCode.java
+++ b/src/main/java/com/ddantime/ddantime/common/exception/ErrorCode.java
@@ -8,12 +8,15 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
     MISSING_HEADER("E001", "필수 헤더가 없습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_UUID("E002", "잘못된 UUID 형식입니다.", HttpStatus.BAD_REQUEST),
-    USER_NOT_FOUND("E003","존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
-    VALIDATION_ERROR("E004","유효성 검사 실패", HttpStatus.BAD_REQUEST),
-    NICKNAME_DUPLICATED("E005", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
-    ONBOARDING_MESSAGE_NOT_FOUND("E010", "온보딩 메시지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ONBOARDING_ALREADY_EXISTS("E007", "해당 사용자에 대한 온보딩 정보가 이미 존재합니다.", HttpStatus.CONFLICT);
+    VALIDATION_ERROR("E002","유효성 검사 실패", HttpStatus.BAD_REQUEST),
+    INVALID_ENUM("E003","잘못된 enum 값이 입력되었습니다.", HttpStatus.BAD_REQUEST),
+
+    INVALID_UUID("E101", "잘못된 UUID 형식입니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("E102","존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    NICKNAME_DUPLICATED("E103", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    ONBOARDING_MESSAGE_NOT_FOUND("E104", "온보딩 메시지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ONBOARDING_ALREADY_EXISTS("E105", "해당 사용자에 대한 온보딩 정보가 이미 존재합니다.", HttpStatus.CONFLICT);
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ddantime/ddantime/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ddantime/ddantime/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ddantime.ddantime.common.exception;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -34,4 +35,8 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponseDto> handleJsonParseError(HttpMessageNotReadableException ex) {
+        return ErrorResponseDto.toResponseEntity(ErrorCode.INVALID_ENUM);
+    }
 }

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/controller/DdanjitController.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/controller/DdanjitController.java
@@ -1,0 +1,35 @@
+package com.ddantime.ddantime.domain.ddanjit.controller;
+
+import com.ddantime.ddantime.common.annotation.RequestUser;
+import com.ddantime.ddantime.domain.ddanjit.dto.DdanjitCreateRequestDto;
+import com.ddantime.ddantime.domain.ddanjit.service.DdanjitService;
+import com.ddantime.ddantime.domain.onboarding.dto.OnboardingRequestDto;
+import com.ddantime.ddantime.domain.onboarding.dto.OnboardingResponseDto;
+import com.ddantime.ddantime.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Ddanjit", description = "딴짓 기록 API")
+@RestController
+@RequestMapping("/api/v1/ddanjit")
+@RequiredArgsConstructor
+public class DdanjitController {
+
+    private final DdanjitService ddanjitService;
+
+    @PostMapping
+    @Operation(summary = "딴짓 기록 생성", description = "사용자의 딴짓 기록을 저장합니다.")
+    public ResponseEntity<Void> createDdanjit(
+            @RequestHeader("Ddantime-User-Id") String uuid,
+            @Parameter(hidden = true) @RequestUser User user,
+            @RequestBody @Valid DdanjitCreateRequestDto requestDto
+    ) {
+        ddanjitService.create(user, requestDto);
+        return ResponseEntity.noContent().build(); // 204 응답
+    }
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/dto/DdanjitCreateRequestDto.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/dto/DdanjitCreateRequestDto.java
@@ -1,0 +1,61 @@
+package com.ddantime.ddantime.domain.ddanjit.dto;
+
+import com.ddantime.ddantime.domain.ddanjit.entity.LocationType;
+import com.ddantime.ddantime.domain.ddanjit.entity.MoodType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class DdanjitCreateRequestDto {
+
+    @Schema(description = "딴짓 기록 날짜", example = "2025-06-17")
+    @NotNull(message = "날짜는 필수입니다.")
+    private LocalDate date;
+
+    @Schema(description = "무엇을 했는지", example = "유튜브 보기")
+    @NotBlank(message = "값이 비어 있을 수 없습니다.")
+    @Size(min = 1, max = 20, message = "최대 20자까지 가능합니다.")
+    private String activity;
+
+    @Schema(description = "시작 시간", example = "12:30")
+    @NotNull(message = "시작 시간은 필수입니다.")
+    private LocalTime startTime;
+
+    @Schema(description = "지속 시간 (분 단위)", example = "30")
+    @Min(value = 1, message = "최소 1분 이상이어야 합니다.")
+    @Max(value = 240, message = "최대 240분(4시간)을 초과할 수 없습니다.")
+    private int durationMin;
+
+    @Schema(description = "장소 (HOME, WORK, SCHOOL, RESTAURANT, CAFE, STREET, OTHER)", example = "CAFE")
+    private LocationType location;
+
+    @AssertTrue(message = "장소가 기타(OTHER)인 경우에만 locationEtc를 입력해야 합니다.")
+    @Schema(hidden = true)
+    public boolean isValidLocationEtc() {
+        if (location == null) return true; // Enum 역직렬화 실패 여부와 별개로 무시
+
+        boolean isEtc = location == LocationType.OTHER;
+
+        // 기타인 경우에는 값이 있어야 함
+        if (isEtc) {
+            return locationEtc != null && !locationEtc.isBlank();
+        }
+
+        // 기타가 아닌 경우에는 값이 없어야 함
+        return locationEtc == null || locationEtc.isBlank();
+    }
+    @Schema(description = "장소가 'OTHER' 경우 직접 입력", example = "버스 안")
+    private String locationEtc;
+
+    @Schema(description = "기분 ( HAPPY, SAD, ANGRY, NEUTRAL, PANIC, CURIOUS )", example = "HAPPY")
+    @NotNull(message = "기분은 필수입니다.")
+    private MoodType mood;
+
+    @Schema(description = "메모 (최대 200자)", example = "오늘은 카페에서 힐링했다.")
+    @Size(max = 200, message = "최대 200자까지 가능합니다.")
+    private String memo;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/dto/DdanjitResponseDto.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/dto/DdanjitResponseDto.java
@@ -1,0 +1,24 @@
+package com.ddantime.ddantime.domain.ddanjit.dto;
+
+import com.ddantime.ddantime.domain.ddanjit.entity.LocationType;
+import com.ddantime.ddantime.domain.ddanjit.entity.MoodType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class DdanjitResponseDto {
+    private Long id;
+    private LocalDate date;
+    private String activity;
+    private LocalTime startTime;
+    private int durationMin;
+    private LocalTime endTime;
+    private LocationType location;
+    private String locationEtc;
+    private MoodType mood;
+    private String memo;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/Ddanjit.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/Ddanjit.java
@@ -1,0 +1,71 @@
+package com.ddantime.ddantime.domain.ddanjit.entity;
+
+import com.ddantime.ddantime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "ddanjit_records")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Ddanjit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false, length = 100)
+    private String activity;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "duration_min", nullable = false)
+    private int durationMin;
+
+    // 종료 시간 (등록 시 계산하여 저장)
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "location", length = 20)
+    @Enumerated(EnumType.STRING)
+    private LocationType location;
+
+    // 기타 장소 (locationType = OTHER인 경우)
+    @Column(name = "location_etc", length = 20)
+    private String locationEtc;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MoodType mood;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    @PreUpdate
+    public void calculateEndTime() {
+        if (startTime != null && durationMin > 0) {
+            this.endTime = startTime.plusMinutes(durationMin);
+        }
+    }
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/LocationType.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/LocationType.java
@@ -1,0 +1,5 @@
+package com.ddantime.ddantime.domain.ddanjit.entity;
+
+public enum LocationType {
+    HOME, WORK, SCHOOL, RESTAURANT, CAFE, STREET, OTHER
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/MoodType.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/entity/MoodType.java
@@ -1,0 +1,5 @@
+package com.ddantime.ddantime.domain.ddanjit.entity;
+
+public enum MoodType {
+    HAPPY, SAD, ANGRY, NEUTRAL, PANIC, CURIOUS
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/repository/DdanjitRepository.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/repository/DdanjitRepository.java
@@ -1,0 +1,7 @@
+package com.ddantime.ddantime.domain.ddanjit.repository;
+
+import com.ddantime.ddantime.domain.ddanjit.entity.Ddanjit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DdanjitRepository extends JpaRepository<Ddanjit, Long> {
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/service/DdanjitService.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/service/DdanjitService.java
@@ -1,0 +1,9 @@
+package com.ddantime.ddantime.domain.ddanjit.service;
+
+import com.ddantime.ddantime.domain.ddanjit.dto.DdanjitCreateRequestDto;
+import com.ddantime.ddantime.domain.ddanjit.dto.DdanjitResponseDto;
+import com.ddantime.ddantime.domain.user.entity.User;
+
+public interface DdanjitService {
+    DdanjitResponseDto create(User user, DdanjitCreateRequestDto requestDto);
+}

--- a/src/main/java/com/ddantime/ddantime/domain/ddanjit/service/DdanjitServiceImpl.java
+++ b/src/main/java/com/ddantime/ddantime/domain/ddanjit/service/DdanjitServiceImpl.java
@@ -1,0 +1,54 @@
+package com.ddantime.ddantime.domain.ddanjit.service;
+
+import com.ddantime.ddantime.domain.ddanjit.dto.DdanjitCreateRequestDto;
+import com.ddantime.ddantime.domain.ddanjit.dto.DdanjitResponseDto;
+import com.ddantime.ddantime.domain.ddanjit.entity.Ddanjit;
+import com.ddantime.ddantime.domain.ddanjit.entity.LocationType;
+import com.ddantime.ddantime.domain.ddanjit.repository.DdanjitRepository;
+import com.ddantime.ddantime.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class DdanjitServiceImpl implements DdanjitService {
+
+    private final DdanjitRepository ddanjitRepository;
+
+    @Override
+    public DdanjitResponseDto create(User user, DdanjitCreateRequestDto dto) {
+
+        Ddanjit record = Ddanjit.builder()
+                .user(user)
+                .date(dto.getDate())
+                .activity(dto.getActivity())
+                .startTime(dto.getStartTime())
+                .durationMin(dto.getDurationMin())
+                .location(dto.getLocation())
+                .locationEtc(dto.getLocation() == LocationType.OTHER ? dto.getLocationEtc() : null)
+                .mood(dto.getMood())
+                .memo(dto.getMemo())
+                .build();
+
+
+        Ddanjit saved = ddanjitRepository.save(record);
+        return toDto(saved);
+    }
+
+    public DdanjitResponseDto toDto(Ddanjit entity) {
+        return DdanjitResponseDto.builder()
+                .id(entity.getId())
+                .date(entity.getDate())
+                .activity(entity.getActivity())
+                .startTime(entity.getStartTime())
+                .durationMin(entity.getDurationMin())
+                .endTime(entity.getEndTime())
+                .location(entity.getLocation())
+                .locationEtc(entity.getLocationEtc())
+                .mood(entity.getMood())
+                .memo(entity.getMemo())
+                .build();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 🔥 작업
- 딴짓 기록 등록 API 구현

## 📋 작업 상세 내용
- 사용자가 하루 중 한 딴짓(행동)을 기록할 수 있도록 등록 API를 구현했습니다.
- 시작 시간과 종료 시간을 입력받아 duration(분 단위)을 자동 계산하여 저장합니다.
- 감정(mood)은 Enum 타입(HAPPY, SAD, ANGRY 등)으로 제한됩니다.
- UUID는 `Ddantime-User-Id` 헤더를 통해 전달받아 사용자 식별에 사용합니다.
- 등록된 딴짓은 `ddanjit_records` 테이블에 저장됩니다.

## 🛠️ 주요 변경사항
- `DdanjitCreateRequestDto`: 등록 요청값 DTO 생성
- `Ddanjit` 엔티티: JPA 기반 딴짓 기록 테이블 매핑
- `DdanjitController`: `/api/v1/ddanjits` POST API 구현
- `DdanjitService`: 비즈니스 로직 처리 및 duration 계산

## 📸 기타 (스크린샷/링크 등)
- 
