### PR TITLE
feat: 오늘의 명언 조회 API 추가 (#9)

### DIFF
--- a/src/main/java/com/ddantime/ddantime/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/controller/QuoteController.java
@@ -1,0 +1,43 @@
+package com.ddantime.ddantime.domain.quote.controller;
+
+import com.ddantime.ddantime.common.annotation.RequestUser;
+import com.ddantime.ddantime.domain.quote.dto.QuoteResponseDto;
+import com.ddantime.ddantime.domain.quote.service.QuoteService;
+import com.ddantime.ddantime.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Quote", description = "오늘의 명언 API")
+@RestController
+@RequestMapping("/api/v1/quotes")
+@RequiredArgsConstructor
+public class QuoteController {
+
+    private final QuoteService quoteService;
+
+    /**
+     * 오늘의 명언 조회
+     * - 이미 조회한 경우 동일 명언 반환
+     * - 처음 조회 시 랜덤 명언 반환 후 기록
+     * @param user
+     * @return
+     */
+    @GetMapping("/today")
+    @Operation(
+            summary = "오늘의 명언 조회",
+            description = "오늘 하루를 시작할 수 있는 짧은 문장을 제공합니다. <br/> 아직 보지 않은 명언 중 하나가 랜덤으로 선택되며, 모든 명언을 다 보면 다시 처음부터 순환됩니다. <br/> 하루 한 번만 조회할 수 있습니다."
+    )
+    public ResponseEntity<QuoteResponseDto> getTodayQuote(
+            @RequestHeader("Ddantime-User-Id") String uuid,
+            @Parameter(hidden = true) @RequestUser User user) {
+        QuoteResponseDto response = quoteService.getTodayQuote(user);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/dto/QuoteResponseDto.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/dto/QuoteResponseDto.java
@@ -1,0 +1,10 @@
+package com.ddantime.ddantime.domain.quote.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuoteResponseDto {
+    private final String content;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/entity/Quote.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/entity/Quote.java
@@ -1,0 +1,21 @@
+package com.ddantime.ddantime.domain.quote.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "quotes")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Quote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/entity/QuoteLog.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/entity/QuoteLog.java
@@ -1,0 +1,41 @@
+package com.ddantime.ddantime.domain.quote.entity;
+
+import com.ddantime.ddantime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quote_logs", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "date"})
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class QuoteLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quote_id", nullable = false)
+    private Quote quote;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/repository/QuoteLogRepository.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/repository/QuoteLogRepository.java
@@ -1,0 +1,18 @@
+package com.ddantime.ddantime.domain.quote.repository;
+
+import com.ddantime.ddantime.domain.quote.entity.QuoteLog;
+import com.ddantime.ddantime.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Set;
+
+public interface QuoteLogRepository extends JpaRepository<QuoteLog, Long> {
+    Optional<QuoteLog> findByUserAndDate(User user, LocalDate date);
+    @Query("SELECT ql.quote.id FROM QuoteLog ql WHERE ql.user = :user")
+    Set<Long> findQuoteIdsByUser(@Param("user") User user);
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/repository/QuoteRepository.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/repository/QuoteRepository.java
@@ -1,0 +1,15 @@
+package com.ddantime.ddantime.domain.quote.repository;
+
+import com.ddantime.ddantime.domain.quote.entity.Quote;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
+
+public interface QuoteRepository extends JpaRepository<Quote, Long> {
+    @Query("SELECT q FROM Quote q WHERE q.id NOT IN :excludeIds ORDER BY function('RANDOM')")
+    List<Quote> findRandomQuoteExcludingIds(@Param("excludeIds") Set<Long> excludeIds, Pageable pageable);
+}

--- a/src/main/java/com/ddantime/ddantime/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/ddantime/ddantime/domain/quote/service/QuoteService.java
@@ -1,0 +1,66 @@
+package com.ddantime.ddantime.domain.quote.service;
+
+import com.ddantime.ddantime.domain.quote.dto.QuoteResponseDto;
+import com.ddantime.ddantime.domain.quote.entity.Quote;
+import com.ddantime.ddantime.domain.quote.entity.QuoteLog;
+import com.ddantime.ddantime.domain.quote.repository.QuoteLogRepository;
+import com.ddantime.ddantime.domain.quote.repository.QuoteRepository;
+import com.ddantime.ddantime.domain.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteService {
+
+    private final QuoteRepository quoteRepository;
+    private final QuoteLogRepository quoteLogRepository;
+
+    @Transactional
+    public QuoteResponseDto getTodayQuote(User user) {
+        LocalDate today = LocalDate.now();
+
+        // 오늘 이미 조회한 명언이 있다면 그대로 반환
+        Optional<QuoteLog> todayQuoteLog = quoteLogRepository.findByUserAndDate(user, today);
+        if (todayQuoteLog.isPresent()) {
+            return toDto(todayQuoteLog.get().getQuote());
+        }
+
+        // 아직 오늘 명언을 보지 않았다면 새로운 명언 추출
+        Set<Long> shownQuoteIds = quoteLogRepository.findQuoteIdsByUser(user);
+
+        List<Quote> availableQuotes = quoteRepository.findRandomQuoteExcludingIds(
+                shownQuoteIds, PageRequest.of(0, 1)
+        );
+
+        if (availableQuotes.isEmpty()) {
+            quoteLogRepository.deleteByUser(user);
+            availableQuotes = quoteRepository.findRandomQuoteExcludingIds(
+                    Collections.emptySet(), PageRequest.of(0, 1)
+            );
+        }
+
+        Quote selected = availableQuotes.get(0);
+
+        // 명언 조회 기록 저장
+        QuoteLog log = QuoteLog.builder()
+                .user(user)
+                .date(today)
+                .quote(selected)
+                .build();
+        quoteLogRepository.save(log);
+
+        return toDto(selected);
+    }
+
+    private QuoteResponseDto toDto(Quote quote) {
+        return QuoteResponseDto.builder()
+                .content(quote.getContent())
+                .build();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 🔥 작업
- 명언 데이터 등록
- 오늘의 명언 조회 API 구현

## 📋 작업 상세 내용
- Quote 엔티티 및 QuoteLog 엔티티 추가
- 사용자가 아직 보지 않은 명언을 무작위로 조회하고, 본 기록을 QuoteLog에 저장
- 모든 명언을 본 경우, 기록을 삭제한 뒤 다시 순환되도록 구현

## 🛠️ 주요 변경사항
- 

## 📸 기타 (스크린샷/링크 등)
- 
