### PR TITLE
feat: 마이페이지 알림설정 (#13)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+	implementation 'com.vladmihalcea:hibernate-types-60:2.21.1' // JSONB 지원 라이브러리
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/controller/NotificationSettingController.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/controller/NotificationSettingController.java
@@ -1,0 +1,47 @@
+package com.ddantime.ddantime.domain.setting.notification.controller;
+
+import com.ddantime.ddantime.common.annotation.RequestUser;
+import com.ddantime.ddantime.domain.onboarding.dto.OnboardingRequestDto;
+import com.ddantime.ddantime.domain.setting.notification.dto.NotificationSettingRequestDto;
+import com.ddantime.ddantime.domain.setting.notification.dto.NotificationSettingResponseDto;
+import com.ddantime.ddantime.domain.setting.notification.service.NotificationSettingService;
+import com.ddantime.ddantime.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/settings/notifications")
+@RequiredArgsConstructor
+@Tag(name = "알림 설정 API", description = "마이페이지 내 알림 설정 관련 API")
+public class NotificationSettingController {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @GetMapping
+    @Operation(summary = "알림 설정 조회", description = "사용자의 알림 설정을 조회합니다.")
+    public ResponseEntity<NotificationSettingResponseDto> getSettings(
+            @RequestHeader("Ddantime-User-Id") String uuid,
+            @Parameter(hidden = true) @RequestUser User user
+    ) {
+        NotificationSettingResponseDto responseDto = notificationSettingService.getSetting(user);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // TODO create 생성 프론트 논의 필요
+    @PutMapping
+    @Operation(summary = "알림 설정 저장", description = "전체 알림 여부, 돌아와요/약속해요 딴타임 알림 여부 및 시간 목록을 설정합니다.")
+    public ResponseEntity<NotificationSettingResponseDto> saveSettings(
+            @RequestHeader("Ddantime-User-Id") String uuid,
+            @Parameter(hidden = true) @RequestUser User user,
+            @RequestBody @Valid NotificationSettingRequestDto requestDto
+    ) {
+        NotificationSettingResponseDto responseDto = notificationSettingService.saveOrUpdate(user, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/dto/NotificationSettingRequestDto.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/dto/NotificationSettingRequestDto.java
@@ -1,0 +1,47 @@
+package com.ddantime.ddantime.domain.setting.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+public class NotificationSettingRequestDto {
+
+    @Schema(description = "전체 알림 허용 여부 (true 설정 시 돌아와요/약속해요 알림도 함께 활성화됨)", example = "true")
+    private boolean allNotificationsEnabled;
+
+    @Schema(description = "5일 이상 딴짓 기록이 없을 때 알림 허용 여부", example = "true")
+    private boolean comebackNotificationEnabled;
+
+    @Schema(description = "하루 최대 1회, 설정된 시간에 알림 허용 여부", example = "false")
+    private boolean promiseNotificationEnabled;
+
+    @Schema(
+            description = "약속해요 딴타임 알림 시간 리스트 (최대 5개). " +
+                    "빈 배열일 수 있으며, 각 값은 HH:mm 형식의 24시간제 문자열이어야 합니다.",
+            example = "[\"08:00\", \"12:00\", \"20:00\"]"
+    )
+    @Size(max = 5, message = "알림 시간은 최대 5개까지 설정할 수 있습니다.")
+    private List<@Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시간 형식은 HH:mm이어야 합니다.") String> promiseTimes;
+
+    public void applySettingsHelper() {
+
+        // 시간에 중복값이 있으면 제거
+        if (this.promiseTimes != null) {
+            this.promiseTimes = this.promiseTimes.stream().distinct().collect(Collectors.toList());
+        }
+
+        // 전체 알림 on이면, 모든 알림 on
+        if (allNotificationsEnabled) {
+            this.comebackNotificationEnabled = true;
+            this.promiseNotificationEnabled = true;
+        }
+    }
+}

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/dto/NotificationSettingResponseDto.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/dto/NotificationSettingResponseDto.java
@@ -1,0 +1,23 @@
+package com.ddantime.ddantime.domain.setting.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class NotificationSettingResponseDto {
+    @Schema(description = "전체 알림 허용 여부", example = "true")
+    private boolean allNotificationsEnabled;
+
+    @Schema(description = "돌아와요 딴타임 알림 허용 여부", example = "true")
+    private boolean comebackNotificationEnabled;
+
+    @Schema(description = "약속해요 딴타임 알림 허용 여부", example = "true")
+    private boolean promiseNotificationEnabled;
+
+    @Schema(description = "약속해요 딴타임 알림 시간 리스트", example = "[\"08:00\", \"12:00\"]")
+    private List<String> promiseTimes;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/entity/NotificationSetting.java
@@ -1,0 +1,36 @@
+package com.ddantime.ddantime.domain.setting.notification.entity;
+
+import com.ddantime.ddantime.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+
+
+@Entity
+@Table(name = "notification_settings")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NotificationSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    private boolean allNotificationsEnabled;    // 전체 알림 ON/OFF
+    private boolean comebackNotificationEnabled; // 돌아와요 딴타임 알림
+    private boolean promiseNotificationEnabled;  // 약속해요 딴타임 알림
+
+    @Column(columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> promiseTimes;
+}

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,11 @@
+package com.ddantime.ddantime.domain.setting.notification.repository;
+
+import com.ddantime.ddantime.domain.setting.notification.entity.NotificationSetting;
+import com.ddantime.ddantime.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+    Optional<NotificationSetting> findByUser(User user);
+}

--- a/src/main/java/com/ddantime/ddantime/domain/setting/notification/service/NotificationSettingService.java
+++ b/src/main/java/com/ddantime/ddantime/domain/setting/notification/service/NotificationSettingService.java
@@ -1,0 +1,56 @@
+package com.ddantime.ddantime.domain.setting.notification.service;
+
+import com.ddantime.ddantime.domain.setting.notification.dto.NotificationSettingRequestDto;
+import com.ddantime.ddantime.domain.setting.notification.dto.NotificationSettingResponseDto;
+import com.ddantime.ddantime.domain.setting.notification.entity.NotificationSetting;
+import com.ddantime.ddantime.domain.setting.notification.repository.NotificationSettingRepository;
+import com.ddantime.ddantime.domain.user.entity.User;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationSettingResponseDto getSetting(User user) {
+        return notificationSettingRepository.findByUser(user)
+                .map(this::toDto)
+                .orElseGet(() -> NotificationSettingResponseDto.builder()
+                        .allNotificationsEnabled(true)
+                        .comebackNotificationEnabled(true)
+                        .promiseNotificationEnabled(true)
+                        .promiseTimes(Collections.emptyList())
+                        .build());
+    }
+
+    @Transactional
+    public NotificationSettingResponseDto saveOrUpdate(User user, NotificationSettingRequestDto dto) {
+        dto.applySettingsHelper();
+
+        NotificationSetting setting = notificationSettingRepository.findByUser(user)
+                .orElseGet(() -> NotificationSetting.builder().user(user).build());
+
+        setting.setAllNotificationsEnabled(dto.isAllNotificationsEnabled());
+        setting.setComebackNotificationEnabled(dto.isComebackNotificationEnabled());
+        setting.setPromiseNotificationEnabled(dto.isPromiseNotificationEnabled());
+        setting.setPromiseTimes(dto.getPromiseTimes());
+
+        NotificationSetting saved = notificationSettingRepository.save(setting);
+        return toDto(saved);
+    }
+
+    private NotificationSettingResponseDto toDto(NotificationSetting setting) {
+        return NotificationSettingResponseDto.builder()
+                .allNotificationsEnabled(setting.isAllNotificationsEnabled())
+                .comebackNotificationEnabled(setting.isComebackNotificationEnabled())
+                .promiseNotificationEnabled(setting.isPromiseNotificationEnabled())
+                .promiseTimes(setting.getPromiseTimes())
+                .build();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 🔥 작업
- 마이페이지 > 알림 설정 저장 및 조회 기능 구현

## 📋 작업 상세 내용
- 알림 설정 조회 API 구현
- 전체 알림 on/off에 따른 하위 알림 자동 조정 로직 추가
- promiseTimes 중복 제거 로직 적용

## 🛠️ 주요 변경사항
- 

## 📸 기타 (스크린샷/링크 등)
- 
